### PR TITLE
[codex] devcontainer에서 Pintos activate 자동 적용

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ RUN echo "jungle ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/jungle
 USER jungle
 WORKDIR /home/jungle
 
-RUN echo "source /workspaces/pintos/activate" >> /home/jungle/.bashrc
+RUN printf '\n# Add Pintos utility commands to PATH for interactive shells.\nif [ -f /workspaces/pintos/activate ]; then\n    source /workspaces/pintos/activate\nfi\n' >> /home/jungle/.bashrc
 
 # Clone the repository
 # RUN git clone https://github.com/casys-kaist/pintos-kaist /home/jungle/pintos


### PR DESCRIPTION
## 요약
- devcontainer Dockerfile에서 대화형 bash 셸이 시작될 때 `/home/jungle/.bashrc`를 통해 `/workspaces/pintos/activate`를 자동으로 source하도록 수정했습니다.
- 워크스페이스 경로가 아직 없거나 사용할 수 없는 경우에도 셸 시작이 깨지지 않도록 파일 존재 여부를 확인합니다.

## 영향
새 Docker 컨테이너에서는 Pintos `utils` 디렉터리가 자동으로 `PATH`에 포함됩니다. 따라서 로그인할 때마다 `source ./activate`를 직접 실행하지 않아도 됩니다.

## 검증
- `git diff --check -- .devcontainer/Dockerfile`
- `bash -n activate`